### PR TITLE
Fix the issue#5 that causes the application to throw "Cannot read property 'send' of null"

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,7 +28,7 @@ const ReadText = (imgfile, oem, psm) => {
                                 // console.log(text)
                                 resolve(text)
                             }).finally(() => {
-                                worker.terminate()
+                                
                             })
                         })
                     });


### PR DESCRIPTION
Simply removing "worker.terminate()" at line 31 of index.js solves the problem. Without this issue being addressed, you'd get "TypeError: Cannot read property 'send' of null" after trying to call ReadText function for the second time onwards. Then you'd have to restart the server to make it work again.

This issue is already discussed here: [https://github.com/goyalabhi1305/tess-based-text-from-image/issues/url](url)